### PR TITLE
Use global font in RelatedItems' styles

### DIFF
--- a/client/src/components/related-items/styles/Carousel.js
+++ b/client/src/components/related-items/styles/Carousel.js
@@ -18,7 +18,6 @@ const Button = styled.button`
   height: 380px;
   background: transparent;
   border: 0;
-  font-family: 'Yantramanav', sans-serif;
   font-weight: 700;
   font-size: 1.75rem;
 `;

--- a/client/src/components/related-items/styles/Category.js
+++ b/client/src/components/related-items/styles/Category.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 const Category = styled.h2`
   text-transform: uppercase;
-  font-family: 'Yantramanav', sans-serif;
   font-weight: 700;
   font-size: 1.15rem;
   margin-top: 50px;

--- a/client/src/components/related-items/styles/Comparison.js
+++ b/client/src/components/related-items/styles/Comparison.js
@@ -11,13 +11,11 @@ const Comparison = styled.div`
 `;
 
 const Category = styled.div`
-  font-family: 'Yantramanav', sans-serif;
   font-weight: 700;
   text-decoration: underline
 `;
 
 const Entry = styled.div`
-  font-family: 'Yantramanav', sans-serif;
 `;
 
 const Break = styled.div`

--- a/client/src/components/related-items/styles/Details.js
+++ b/client/src/components/related-items/styles/Details.js
@@ -7,14 +7,12 @@ const Container = styled.div`
 
 const Category = styled.div`
   text-transform: uppercase;
-  font-family: 'Yantramanav', sans-serif;
   font-weight: 400;
   font-size: .9rem;
 `;
 
 const Name = styled.div`
   width: max-content;
-  font-family: 'Yantramanav', sans-serif;
   font-weight: 700;
   font-size: 1.1rem;
 
@@ -27,7 +25,6 @@ const Price = styled.div``;
 
 const DefaultPrice = styled.span`
   text-transform: uppercase;
-  font-family: 'Yantramanav', sans-serif;
   font-weight: 400;
   font-size: .9rem;
 `;
@@ -36,7 +33,6 @@ const DiscountPrice = styled.span`
   padding-left: 4px;
   color: red;
   text-transform: uppercase;
-  font-family: 'Yantramanav', sans-serif;
   font-weight: 400;
   font-size: .9rem;
 `;

--- a/client/src/components/related-items/styles/Modal.js
+++ b/client/src/components/related-items/styles/Modal.js
@@ -26,7 +26,6 @@ const Close = styled.button`
   position: absolute;
   top: 10px;
   left: 20px;
-  font-family: 'Yantramanav', sans-serif;
 `;
 
 export { Overlay, Content, Close };

--- a/client/src/components/related-items/styles/Outfit.js
+++ b/client/src/components/related-items/styles/Outfit.js
@@ -7,7 +7,6 @@ const Container = styled.div`
 `;
 
 const Empty = styled.div`
-  font-family: 'Yantramanav', sans-serif;
 `;
 
 export { Container, Empty };


### PR DESCRIPTION
- Remove font overrides to conform with the project's font family